### PR TITLE
Mobile nav menu no longer shifts content.

### DIFF
--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -14,6 +14,10 @@ header .nav-wrapper {
   transition: top 0.3s ease-in-out;
 }
 
+header .nav-wrapper:has(nav[aria-expanded="true"]) {
+  pointer-events: all;
+}
+
 header nav a,
 header .nav-hamburger button {
   pointer-events: auto;

--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -56,8 +56,6 @@ function toggleMenu(nav, navSections, forceExpanded = null) {
   const expanded = forceExpanded !== null ? !forceExpanded : nav.getAttribute('aria-expanded') === 'true';
   const button = nav.querySelector('.nav-hamburger button');
 
-  document.body.style.position = (expanded || isDesktop.matches) ? '' : 'fixed';
-
   nav.setAttribute('aria-expanded', expanded ? 'false' : 'true');
   toggleAllNavSections(navSections, expanded || isDesktop.matches ? 'false' : 'true');
   button.setAttribute('aria-label', expanded ? 'Open navigation' : 'Close navigation');

--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -55,7 +55,9 @@ function toggleAllNavSections(sections, expanded = false) {
 function toggleMenu(nav, navSections, forceExpanded = null) {
   const expanded = forceExpanded !== null ? !forceExpanded : nav.getAttribute('aria-expanded') === 'true';
   const button = nav.querySelector('.nav-hamburger button');
-  document.body.style.overflowY = (expanded || isDesktop.matches) ? '' : 'hidden';
+
+  document.body.style.position = (expanded || isDesktop.matches) ? '' : 'fixed';
+
   nav.setAttribute('aria-expanded', expanded ? 'false' : 'true');
   toggleAllNavSections(navSections, expanded || isDesktop.matches ? 'false' : 'true');
   button.setAttribute('aria-label', expanded ? 'Open navigation' : 'Close navigation');

--- a/package.json
+++ b/package.json
@@ -4,8 +4,11 @@
   "version": "1.0.0",
   "scripts": {
     "lint:js": "eslint .",
-    "lint:css": "stylelint blocks/**/*.css styles/*.css",
-    "lint": "npm run lint:js && npm run lint:css"
+    "lint:js:fix": "eslint . --fix",
+    "lint:css": "stylelint 'blocks/**/*.css' 'styles/*.css'",
+    "lint:css:windows": "stylelint \"blocks/**/*.css\" \"styles/*.css\"",
+    "lint": "npm run lint:js && npm run lint:css",
+    "lint:windows": "npm run lint:js:fix && npm run lint:css:windows"
   },
   "devDependencies": {
     "@babel/core": "7.21.0",

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -37,6 +37,13 @@
   --nav-height: 64px;
 }
 
+/* disabling scroll on html in favor of 
+having it on the body, so scrolling can be blocked
+by the mobile nav menu. */
+html {
+  overflow: hidden;
+}
+
 html, body {
   width: 100%;
   height: 100%;
@@ -46,6 +53,7 @@ body {
   margin: 0;
   font-family: var(--font-family);
   overflow-x: hidden;
+  overflow-y: auto;
   box-sizing: border-box;
   display: none;
 }


### PR DESCRIPTION
Removes scrolling for html, instead puts main scrollbar on the body. This allows the mobile nav menu to cover the scrollbar and prevent scrolling while its open, while also stopping the layout shift caused from removing the scrollbar

Fix #31 

Test URLs:
- Before: https://main--www--headwire-edge-delivery.hlx.page/
- After: https://mobile-menu-content-shift--www--headwire-edge-delivery.hlx.page/
