### PR TITLE
fixed mobile menu not resetting the 'dropdown-open' class upon closing

### DIFF
--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -41,7 +41,7 @@ function onDialogClose(nav, navSections) {
 
   nav.setAttribute('aria-expanded', 'false');
   toggleAllNavSections(navSections, 'false');
-  navSections.classList.remove('dropdown-open')
+  navSections.classList.remove('dropdown-open');
   button.setAttribute('aria-label', 'Open navigation');
   navSections.querySelector('.button-dropdown-wrapper')?.classList?.remove('open');
 }

--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -41,6 +41,7 @@ function onDialogClose(nav, navSections) {
 
   nav.setAttribute('aria-expanded', 'false');
   toggleAllNavSections(navSections, 'false');
+  navSections.classList.remove('dropdown-open')
   button.setAttribute('aria-label', 'Open navigation');
   navSections.querySelector('.button-dropdown-wrapper')?.classList?.remove('open');
 }


### PR DESCRIPTION
Fixing the mobile sub menu not resetting its open class upon closing the dialog

Test URLs:
- Before: https://main--www--headwire-edge-delivery.hlx.page/
- After: https://mobile-menu-close-fix--www--headwire-edge-delivery.hlx.page/
