### PR TITLE
Trigger reindex on content publish/unpublish

### DIFF
--- a/.github/workflows/reindex.yaml
+++ b/.github/workflows/reindex.yaml
@@ -1,0 +1,18 @@
+name: Trigger reindexing
+on:
+  workflow_dispatch:
+  repository_dispatch:
+    type:
+      resource-published
+      resource-unpublished
+
+jobs:
+  trigger:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch reindex event
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.SEARCH_INDEX_ACCESS_TOKEN }}
+          repository: headwire-edge-delivery/search-index
+          event-type: reindex


### PR DESCRIPTION
This change has no bearing on site speed as it does not touch client code, just adds an automatic reindex workflow.